### PR TITLE
Add GMS Location Provider

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1174,6 +1174,8 @@
          that matches the signature of at least one package on this list.
          -->
     <string-array name="config_locationProviderPackageNames" translatable="false">
+        <!-- GMS location provider -->
+        <item>com.google.android.gms</item>
         <!-- The standard AOSP fused location provider -->
         <item>com.android.location.fused</item>
     </string-array>


### PR DESCRIPTION
GMS Location Provider used in all Nexus devices and is much better then AOSP fuse.
